### PR TITLE
feat: replace client-side-prover w/ edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,68 @@
 version = 4
 
 [[package]]
+name = "acir"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acir_field",
+ "base64 0.21.7",
+ "bincode",
+ "brillig",
+ "flate2",
+ "serde",
+ "serde-big-array",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "acir_field"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "serde",
+]
+
+[[package]]
+name = "acvm"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acir",
+ "acvm_blackbox_solver",
+ "brillig_vm",
+ "fxhash",
+ "indexmap 1.9.3",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "acvm_blackbox_solver"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acir",
+ "blake2",
+ "blake3",
+ "k256 0.11.6",
+ "keccak",
+ "libaes",
+ "num-bigint 0.4.6",
+ "p256 0.11.1",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "addchain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +189,7 @@ dependencies = [
  "hex-literal",
  "indexmap 2.7.0",
  "itoa",
- "k256",
+ "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
@@ -234,9 +296,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -246,12 +319,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe 0.6.0",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
@@ -295,6 +389,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe 0.6.0",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +426,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -340,6 +464,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,12 +490,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe 0.6.0",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "ark-secp256r1"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
 ]
@@ -379,8 +531,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
  "num-bigint 0.4.6",
 ]
@@ -394,6 +559,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -411,6 +587,16 @@ name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -858,6 +1044,12 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -903,7 +1095,7 @@ source = "git+https://github.com/argumentcomputer/bellpepper?branch=dev#d0225bf6
 dependencies = [
  "bellpepper-core",
  "byteorder",
- "ff",
+ "ff 0.13.0",
  "itertools 0.12.1",
 ]
 
@@ -915,7 +1107,7 @@ checksum = "1d8abb418570756396d722841b19edfec21d4e89e1cf8990610663040ecb1aea"
 dependencies = [
  "blake2s_simd",
  "byteorder",
- "ff",
+ "ff 0.13.0",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -1024,6 +1216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,12 +1311,33 @@ checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
  "byte-slice-cast",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "serde",
  "subtle",
+]
+
+[[package]]
+name = "brillig"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acir_field",
+ "serde",
+]
+
+[[package]]
+name = "brillig_vm"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acir",
+ "acvm_blackbox_solver",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1381,7 +1603,7 @@ name = "circom_witnesscalc"
 version = "0.2.0"
 source = "git+https://github.com/pluto/circom-witnesscalc#722a3936999a8dd894f53cd498b019b65c90ac10"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "bindgen 0.70.1",
@@ -1483,9 +1705,9 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap 4.5.23",
- "client-side-prover",
  "console_error_panic_hook",
- "elliptic-curve",
+ "edge-prover",
+ "elliptic-curve 0.13.8",
  "futures",
  "getrandom 0.2.15",
  "hex",
@@ -1493,7 +1715,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "js-sys",
- "p256",
+ "p256 0.13.2",
  "parking_lot",
  "pin-project-lite",
  "proofs",
@@ -1506,8 +1728,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "spansy",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror 1.0.69",
  "time",
  "tls-client",
@@ -1551,10 +1773,10 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array 1.1.1",
  "getrandom 0.2.15",
- "group",
+ "group 0.13.0",
  "grumpkin-msm",
  "halo2curves",
  "itertools 0.13.0",
@@ -1707,7 +1929,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.19",
  "yaml-rust2",
 ]
 
@@ -1853,6 +2075,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +2122,18 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -2069,6 +2312,16 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "der"
@@ -2297,17 +2550,86 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.9",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
  "serdect",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "edge-frontend"
+version = "0.1.0"
+source = "git+https://github.com/pluto/edge?rev=cb2c3b5df4cabe7e7bd150f0a5de51669f8409db#cb2c3b5df4cabe7e7bd150f0a5de51669f8409db"
+dependencies = [
+ "acvm",
+ "ark-bn254 0.5.0",
+ "bellpepper-core",
+ "edge-prover",
+ "halo2curves",
+ "noirc_abi",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "edge-prover"
+version = "0.1.0"
+source = "git+https://github.com/pluto/edge?rev=cb2c3b5df4cabe7e7bd150f0a5de51669f8409db#cb2c3b5df4cabe7e7bd150f0a5de51669f8409db"
+dependencies = [
+ "bellpepper",
+ "bellpepper-core",
+ "bincode",
+ "bitvec",
+ "byteorder",
+ "cfg-if",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array 1.1.1",
+ "getrandom 0.2.15",
+ "group 0.13.0",
+ "grumpkin-msm",
+ "halo2curves",
+ "itertools 0.13.0",
+ "neptune",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "pairing",
+ "proptest",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rayon",
+ "rayon-scan",
+ "ref-cast",
+ "serde",
+ "sha3",
+ "static_assertions",
+ "subtle",
+ "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
@@ -2316,10 +2638,22 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
- "enum-ordinalize",
+ "enum-ordinalize 3.1.15",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize 4.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2330,21 +2664,41 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array 0.14.7",
- "group",
+ "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "serdect",
  "subtle",
  "zeroize",
@@ -2376,6 +2730,26 @@ checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -2465,6 +2839,16 @@ dependencies = [
 
 [[package]]
 name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
@@ -2527,6 +2911,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2696,6 +3090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,11 +3188,22 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_xorshift",
@@ -2846,8 +3260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db81d01d0bbfec9f624d7590fc6929ee2537a64ec1e080d8f8c9e2d2da291405"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",
@@ -3416,6 +3830,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iter-extended"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,16 +3928,28 @@ dependencies = [
 
 [[package]]
 name = "k256"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3616,6 +4047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "libaes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82903360c009b816f5ab72a9b68158c27c301ee2c3f20655b55c5e589e7d3bb7"
+
+[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,7 +4090,7 @@ name = "light-poseidon"
 version = "0.2.0"
 source = "git+https://github.com/pluto/light-poseidon#6f44432cdcf60767458c599d2c7c7fde79892d84"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
  "num-bigint 0.4.6",
  "thiserror 1.0.69",
@@ -4122,7 +4559,7 @@ dependencies = [
  "blake2s_simd",
  "blstrs",
  "byteorder",
- "ff",
+ "ff 0.13.0",
  "generic-array 0.14.7",
  "pasta_curves",
  "serde",
@@ -4140,6 +4577,31 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noirc_abi"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acvm",
+ "iter-extended",
+ "noirc_printable_type",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "noirc_printable_type"
+version = "1.0.0-beta.2"
+source = "git+https://github.com/noir-lang/noir?rev=v1.0.0-beta.2#1a2a08cbcb68646ff1aaef383cfc1798933c1355"
+dependencies = [
+ "acvm",
+ "serde",
+]
 
 [[package]]
 name = "nom"
@@ -4188,8 +4650,8 @@ dependencies = [
  "chrono",
  "clap 4.5.23",
  "client",
- "client-side-prover",
  "config",
+ "edge-frontend",
  "eyre",
  "futures",
  "futures-util",
@@ -4197,10 +4659,10 @@ dependencies = [
  "http 1.2.0",
  "hyper",
  "hyper-util",
- "k256",
+ "k256 0.13.4",
  "nom",
  "notary-server",
- "p256",
+ "p256 0.13.2",
  "proofs",
  "reqwest",
  "rs_merkle 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4252,10 +4714,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "k256",
+ "k256 0.13.4",
  "notify",
- "p256",
- "pkcs8",
+ "p256 0.13.2",
+ "pkcs8 0.10.2",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -4517,12 +4979,23 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "primeorder",
  "serdect",
  "sha2",
@@ -4534,7 +5007,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -4615,8 +5088,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "hex",
  "lazy_static",
  "rand 0.8.5",
@@ -4839,12 +5312,22 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4946,7 +5429,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "serdect",
 ]
 
@@ -4967,7 +5450,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -5027,9 +5510,9 @@ dependencies = [
  "byteorder",
  "cargo_metadata",
  "circom_witnesscalc",
- "client-side-prover",
  "derive_more 2.0.1",
- "ff",
+ "edge-prover",
+ "ff 0.13.0",
  "halo2curves",
  "hex",
  "itertools 0.13.0",
@@ -5532,6 +6015,17 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -5879,14 +6373,28 @@ dependencies = [
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.9",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -5965,6 +6473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6100,7 +6617,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -6203,6 +6720,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -6276,12 +6803,22 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -6363,9 +6900,28 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6649,14 +7205,14 @@ dependencies = [
  "hmac",
  "indexmap 1.9.3",
  "log",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "ring",
  "sct",
  "serde",
  "serde_json",
  "sha2",
- "strum_macros",
+ "strum_macros 0.26.4",
  "thiserror 2.0.6",
  "tls-core",
  "tls-parser",
@@ -6763,12 +7319,12 @@ dependencies = [
  "blake3",
  "derive_builder 0.12.0",
  "getrandom 0.2.15",
- "k256",
+ "k256 0.13.4",
  "mpz-circuits",
  "mpz-core",
  "mpz-garble-core",
  "opaque-debug",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "ring",
@@ -6835,7 +7391,7 @@ dependencies = [
  "mpz-garble",
  "mpz-ot",
  "mpz-share-conversion",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "serde",
  "serio",
@@ -6919,7 +7475,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hmac",
  "log",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "ring",
  "sct",
@@ -6979,7 +7535,7 @@ dependencies = [
  "mpz-ole",
  "mpz-ot",
  "mpz-share-conversion",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
@@ -7089,7 +7645,7 @@ dependencies = [
  "opaque-debug",
  "rand 0.8.5",
  "serio",
- "signature",
+ "signature 2.2.0",
  "thiserror 1.0.69",
  "tlsn-common",
  "tlsn-core",
@@ -7169,7 +7725,7 @@ checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bincode",
  "bytes",
- "educe",
+ "educe 0.4.23",
  "futures-core",
  "futures-sink",
  "pin-project 1.1.7",
@@ -7227,6 +7783,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -7234,7 +7802,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -7248,6 +7816,19 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.7.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -7256,7 +7837,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -7881,9 +8462,9 @@ version = "0.1.0"
 source = "git+https://github.com/pluto/web-prover-circuits?rev=0a09df087612d45fa3b0d5914d93c72417edb58b#0a09df087612d45fa3b0d5914d93c72417edb58b"
 dependencies = [
  "anyhow",
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "client-side-prover",
- "ff",
+ "ff 0.13.0",
  "halo2curves",
  "light-poseidon",
  "num-bigint 0.4.6",
@@ -8205,6 +8786,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ chrono     ="0.4"
 
 tracing-test="0.2"
 
+# rand 0.9.0 released January 27th has breaking changes since the 0.8 series
+# https://github.com/lurk-lab/grumpkin-msm/pull/15
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+
 [profile.dev]
 opt-level      =1
 split-debuginfo="unpacked"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,7 +29,7 @@ tls-core          ={ workspace=true }
 tlsn-common       ={ workspace=true }
 tlsn-utils        ={ workspace=true }
 tlsn-formats      ={ git="https://github.com/tlsnotary/tlsn.git", tag="v0.1.0-alpha.7" }
-client-side-prover={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+edge-prover={ git="https://github.com/pluto/edge", rev="cb2c3b5df4cabe7e7bd150f0a5de51669f8409db" }
 web-prover-core   ={ workspace=true }
 
 # TLSN

--- a/client/src/proof.rs
+++ b/client/src/proof.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use client_side_prover::supernova::PublicParams;
+use edge_prover::supernova::PublicParams;
 use proofs::{
   program::{
     data::{InitializedSetup, InstanceParams, NotExpanded, Online, ProofParams, SetupParams},

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -14,7 +14,7 @@ tlsn-core  ={ workspace=true }
 tlsn-common={ workspace=true }
 chrono     ={ workspace=true }
 
-client-side-prover={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+edge-frontend={ git="https://github.com/pluto/edge.git", rev="cb2c3b5df4cabe7e7bd150f0a5de51669f8409db"}
 proofs={ workspace=true }
 client={ workspace=true }
 web-prover-core={ workspace=true }

--- a/notary/src/errors.rs
+++ b/notary/src/errors.rs
@@ -36,7 +36,7 @@ pub enum ProxyError {
   Sign(Box<dyn std::error::Error + Send + 'static>),
 
   #[error("transparent")]
-  SuperNovaError(#[from] client_side_prover::supernova::error::SuperNovaError),
+  SuperNovaError(#[from] edge_prover::supernova::error::SuperNovaError),
 
   #[error("Session ID Error: {0}")]
   InvalidSessionId(String),

--- a/notary/src/origo_verifier.rs
+++ b/notary/src/origo_verifier.rs
@@ -5,7 +5,7 @@
 //! - JSON: JSON extract
 use std::collections::HashMap;
 
-use client_side_prover::supernova::snark::{CompressedSNARK, VerifierKey};
+use edge_prover::supernova::snark::{CompressedSNARK, VerifierKey};
 use proofs::{
   circuits::{construct_setup_data_from_fs, PROVING_PARAMS_512},
   program::data::{CircuitData, Offline, Online, SetupParams},

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -14,7 +14,7 @@ tls-client2={ workspace=true } # a bit of an odd dependency to have in here imo 
 derive_more={ workspace=true }
 
 hex                                 ="0.4"
-client-side-prover                  ={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+edge-prover={ git="https://github.com/pluto/edge.git", rev="cb2c3b5df4cabe7e7bd150f0a5de51669f8409db"}
 ff                                  ={ workspace=true }
 bellpepper-core                     ="0.4"
 halo2curves                         ="0.6.1"

--- a/proofs/src/errors.rs
+++ b/proofs/src/errors.rs
@@ -81,9 +81,9 @@ pub enum ProofError {
   #[error(transparent)]
   Bincode(#[from] bincode::ErrorKind),
 
-  /// The error is a client_side_prover::supernova::error::SuperNovaError
+  /// The error is a edge_prover::supernova::error::SuperNovaError
   #[error(transparent)]
-  SuperNova(#[from] client_side_prover::supernova::error::SuperNovaError),
+  SuperNova(#[from] edge_prover::supernova::error::SuperNovaError),
 
   /// The error is a json key error
   #[error("json key not found: {0}")]

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -34,7 +34,7 @@
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use circom::CircomCircuit;
-use client_side_prover::{
+use edge_prover::{
   provider::GrumpkinEngine,
   spartan::batched::BatchedRelaxedR1CSSNARK,
   supernova::{snark::CompressedSNARK, PublicParams, TrivialCircuit},
@@ -59,7 +59,7 @@ pub mod setup;
 #[cfg(test)] pub(crate) mod tests;
 
 /// Represents the first elliptic curve engine used in the proof system.
-pub type E1 = client_side_prover::provider::Bn256EngineKZG;
+pub type E1 = edge_prover::provider::Bn256EngineKZG;
 /// Represents the second elliptic curve engine used in the proof system.
 pub type E2 = GrumpkinEngine;
 /// Represents the group associated with the first elliptic curve engine.
@@ -68,9 +68,9 @@ pub type G1 = <E1 as Engine>::GE;
 pub type G2 = <E2 as Engine>::GE;
 /// Represents the evaluation engine for the first elliptic curve.
 pub type EE1 =
-  client_side_prover::provider::hyperkzg::EvaluationEngine<halo2curves::bn256::Bn256, E1>;
+  edge_prover::provider::hyperkzg::EvaluationEngine<halo2curves::bn256::Bn256, E1>;
 /// Represents the evaluation engine for the second elliptic curve.
-pub type EE2 = client_side_prover::provider::ipa_pc::EvaluationEngine<E2>;
+pub type EE2 = edge_prover::provider::ipa_pc::EvaluationEngine<E2>;
 /// Represents the SNARK for the first elliptic curve.
 pub type S1 = BatchedRelaxedR1CSSNARK<E1, EE1>;
 /// Represents the SNARK for the second elliptic curve.
@@ -80,10 +80,10 @@ pub type F<G> = <G as Group>::Scalar;
 
 /// Represents the params needed to create `PublicParams` alongside the circuits' R1CSs.
 /// Specifically typed to the `proofs` crate choices of curves and engines.
-pub type AuxParams = client_side_prover::supernova::AuxParams<E1>;
+pub type AuxParams = edge_prover::supernova::AuxParams<E1>;
 /// The `ProverKey` needed to create a `CompressedSNARK` using the `proofs` crate choices of curves
 /// and engines.
-pub type ProverKey = client_side_prover::supernova::snark::ProverKey<E1, S1, S2>;
+pub type ProverKey = edge_prover::supernova::snark::ProverKey<E1, S1, S2>;
 /// The `VerifierKey` needed to create a `CompressedSNARK` using the `proofs` crate choices of
 /// curves and engines.
-pub type VerifierKey = client_side_prover::supernova::snark::VerifierKey<E1, S1, S2>;
+pub type VerifierKey = edge_prover::supernova::snark::VerifierKey<E1, S1, S2>;

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -13,7 +13,7 @@ use std::{
   sync::Arc,
 };
 
-use client_side_prover::{fast_serde::FastSerde, supernova::get_circuit_shapes};
+use edge_prover::{fast_serde::FastSerde, supernova::get_circuit_shapes};
 use serde_json::json;
 
 use super::*;

--- a/proofs/src/program/mod.rs
+++ b/proofs/src/program/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use circom::{r1cs::R1CS, witness::generate_witness_from_generator_type};
-use client_side_prover::{
+use edge_prover::{
   supernova::{NonUniformCircuit, RecursiveSNARK, StepCircuit},
   traits::{snark::default_ck_hint, Dual},
 };

--- a/proofs/src/program/mod.rs
+++ b/proofs/src/program/mod.rs
@@ -32,6 +32,8 @@ use crate::{
   },
 };
 
+pub mod noir;
+
 pub mod data;
 pub mod manifest;
 pub mod utils;

--- a/proofs/src/program/noir.rs
+++ b/proofs/src/program/noir.rs
@@ -1,0 +1,55 @@
+use edge_frontend::error::FrontendError;
+use edge_frontend::noir::NoirProgram;
+use edge_frontend::program::{Memory, run as run_noir, compress as compress_noir};
+use edge_frontend::setup::{Ready, Setup};
+use edge_frontend::CompressedSNARK;
+use super::*;
+
+// FIXME: psetup input must be online
+pub async fn run<M: Memory>(
+  psetup: &Setup<Ready<M>>,
+) -> Result<RecursiveSNARK<E1>, FrontendError> {
+  let recursive_snark = run_noir(psetup)?;
+  Ok(recursive_snark)
+}
+
+pub fn compress<M: Memory>(
+  setup: &Setup<Ready<M>>,
+  recursive_snark: &RecursiveSNARK<E1>,
+) -> Result<CompressedSNARK, FrontendError> {
+  let compressed_snark = compress_noir(setup, recursive_snark)?;
+  Ok(compressed_snark)
+}
+
+// paths: "target/collatz_even.json"
+pub fn initialize_circuit_list(paths: &Vec<&str>) -> Vec<NoirProgram> {
+  paths
+    .iter()
+    .enumerate()
+    .map(|(i, path)| {
+      let mut program = read_noir_program(path).unwrap();
+      program.index = i;
+      program
+    })
+    .collect::<Vec<_>>()
+}
+
+pub fn read_noir_program(path: &str) -> Result<NoirProgram, ProofError> {
+  let path = std::path::PathBuf::from(path);
+
+  // Get the current working directory
+  let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+  let absolute_path = current_dir.join(&path);
+
+  match std::fs::read(&path) {
+    Ok(bytecode) => Ok(NoirProgram::new(&bytecode)),
+    Err(e) => {
+      panic!(
+        "Failed to read Noir program file.\nRelative path: '{}'\nAbsolute path: '{}'\nError: {}",
+        path.display(),
+        absolute_path.display(),
+        e
+      );
+    },
+  }
+}

--- a/proofs/src/setup.rs
+++ b/proofs/src/setup.rs
@@ -23,7 +23,7 @@
 
 use std::io::Cursor;
 
-use client_side_prover::{
+use edge_prover::{
   fast_serde::{self, FastSerde, SerdeByteError, SerdeByteTypes},
   supernova::snark::CompressedSNARK,
   traits::{Dual, Engine},
@@ -47,7 +47,7 @@ pub struct ProvingParams {
 
 impl FastSerde for ProvingParams {
   /// Initialize ProvingParams from an efficiently serializable data format.
-  fn from_bytes(bytes: &Vec<u8>) -> Result<Self, SerdeByteError> {
+  fn from_bytes(bytes: &[u8]) -> Result<Self, SerdeByteError> {
     let mut cursor = Cursor::new(bytes);
     Self::validate_header(&mut cursor, SerdeByteTypes::ProverParams, 3)?;
 
@@ -86,7 +86,7 @@ impl FastSerde for ProvingParams {
 
 impl ProvingParams {
   /// Method used externally to initialize all the backend data needed to create a verifiable proof
-  /// with [`client_side_prover`] and `proofs` crate. Intended to be used in combination with setup,
+  /// with [`edge_prover`] and `proofs` crate. Intended to be used in combination with setup,
   /// which creates these values offline to be loaded at or before proof creation or verification.
   ///
   /// # Arguments

--- a/proofs/src/tests/mod.rs
+++ b/proofs/src/tests/mod.rs
@@ -10,7 +10,7 @@ use circuits::{
   JSON_EXTRACTION_512B_R1CS, MAX_STACK_HEIGHT, PLAINTEXT_AUTHENTICATION_512B_GRAPH,
   PLAINTEXT_AUTHENTICATION_512B_R1CS,
 };
-use client_side_prover::supernova::RecursiveSNARK;
+use edge_prover::supernova::RecursiveSNARK;
 use inputs::{
   complex_manifest, complex_request_inputs, complex_response_inputs, simple_request_inputs,
   simple_response_inputs,


### PR DESCRIPTION
## Summary
I updated dependencies to fix random number generator compatibility issues with grumpkin-msm and replaced `client_side_prover` with `edge-prover` and `edge-frontend`.